### PR TITLE
TouchableNativeFeedback vs. TouchableWithoutFeedback

### DIFF
--- a/morph/react-native/block-wrap.js
+++ b/morph/react-native/block-wrap.js
@@ -16,7 +16,7 @@ export const enter = (node, parent, state) => {
   }
 
   if (node.action) {
-    const block = 'TouchableNativeFeedback'
+    const block = 'TouchableHighlight'
     state.use(block)
     state.render.push(
       `<${block}

--- a/morph/react-native/block-wrap.js
+++ b/morph/react-native/block-wrap.js
@@ -1,40 +1,40 @@
-import { getProp, isCode } from '../utils.js'
-import getBlockName from './get-block-name.js'
-import safe from '../react/safe.js'
-import wrap from '../react/wrap.js'
+import { getProp, isCode } from "../utils.js";
+import getBlockName from "./get-block-name.js";
+import safe from "../react/safe.js";
+import wrap from "../react/wrap.js";
 
 export const enter = (node, parent, state) => {
-  const name = getBlockName(node, parent, state)
+  const name = getBlockName(node, parent, state);
 
   if (
-    name === 'Text' &&
+    name === "Text" &&
     parent &&
     parent.parent &&
     (parent.parent.backgroundImage || parent.parent.ensureBackgroundColor)
   ) {
-    node.ensureBackgroundColor = true
+    node.ensureBackgroundColor = true;
   }
 
   if (node.action) {
-    const block = 'TouchableWithoutFeedback'
-    state.use(block)
+    const block = "TouchableNativeFeedback";
+    state.use(block);
     state.render.push(
       `<${block}
           activeOpacity={0.7}
           onPress=${wrap(node.action)}
           underlayColor='transparent'>`
-    )
-    node.wrapEnd = `</${block}>`
+    );
+    node.wrapEnd = `</${block}>`;
   } else if (node.teleport) {
-    state.use('Link')
-    let to = getProp(node, 'teleportTo').value.value
+    state.use("Link");
+    let to = getProp(node, "teleportTo").value.value;
 
-    if (to.startsWith('/') || to === '..') {
-      to = safe(to)
+    if (to.startsWith("/") || to === "..") {
+      to = safe(to);
     } else {
-      to = isCode(to) ? `\${${to}}` : to
-      to = `{\`\${props.match.url === '/' ? '' : props.match.url}/${to}\`}`
-      state.withRouter = true
+      to = isCode(to) ? `\${${to}}` : to;
+      to = `{\`\${props.match.url === '/' ? '' : props.match.url}/${to}\`}`;
+      state.withRouter = true;
     }
 
     state.render.push(
@@ -42,16 +42,16 @@ export const enter = (node, parent, state) => {
           activeOpacity={0.7}
           to=${to}
           underlayColor='transparent'>`
-    )
-    node.wrapEnd = '</Link>'
+    );
+    node.wrapEnd = "</Link>";
   } else if (node.goTo) {
     // const goTo = getProp(node, 'goTo')
     // TODO https://facebook.github.io/react-native/docs/linking.html
   }
-}
+};
 
 export const leave = (node, parent, state) => {
   if (node.wrapEnd) {
-    state.render.push(node.wrapEnd)
+    state.render.push(node.wrapEnd);
   }
-}
+};

--- a/morph/react-native/block-wrap.js
+++ b/morph/react-native/block-wrap.js
@@ -1,13 +1,13 @@
-import { getProp, isCode } from "../utils.js";
-import getBlockName from "./get-block-name.js";
-import safe from "../react/safe.js";
-import wrap from "../react/wrap.js";
+import { getProp, isCode } from '../utils.js';
+import getBlockName from './get-block-name.js';
+import safe from '../react/safe.js';
+import wrap from '../react/wrap.js';
 
 export const enter = (node, parent, state) => {
   const name = getBlockName(node, parent, state);
 
   if (
-    name === "Text" &&
+    name === 'Text' &&
     parent &&
     parent.parent &&
     (parent.parent.backgroundImage || parent.parent.ensureBackgroundColor)
@@ -16,7 +16,7 @@ export const enter = (node, parent, state) => {
   }
 
   if (node.action) {
-    const block = "TouchableNativeFeedback";
+    const block = 'TouchableNativeFeedback';
     state.use(block);
     state.render.push(
       `<${block}
@@ -26,10 +26,10 @@ export const enter = (node, parent, state) => {
     );
     node.wrapEnd = `</${block}>`;
   } else if (node.teleport) {
-    state.use("Link");
-    let to = getProp(node, "teleportTo").value.value;
+    state.use('Link');
+    let to = getProp(node, 'teleportTo').value.value;
 
-    if (to.startsWith("/") || to === "..") {
+    if (to.startsWith('/') || to === '..') {
       to = safe(to);
     } else {
       to = isCode(to) ? `\${${to}}` : to;
@@ -43,7 +43,7 @@ export const enter = (node, parent, state) => {
           to=${to}
           underlayColor='transparent'>`
     );
-    node.wrapEnd = "</Link>";
+    node.wrapEnd = '</Link>';
   } else if (node.goTo) {
     // const goTo = getProp(node, 'goTo')
     // TODO https://facebook.github.io/react-native/docs/linking.html

--- a/morph/react-native/block-wrap.js
+++ b/morph/react-native/block-wrap.js
@@ -1,10 +1,10 @@
-import { getProp, isCode } from '../utils.js';
-import getBlockName from './get-block-name.js';
-import safe from '../react/safe.js';
-import wrap from '../react/wrap.js';
+import { getProp, isCode } from '../utils.js'
+import getBlockName from './get-block-name.js'
+import safe from '../react/safe.js'
+import wrap from '../react/wrap.js'
 
 export const enter = (node, parent, state) => {
-  const name = getBlockName(node, parent, state);
+  const name = getBlockName(node, parent, state)
 
   if (
     name === 'Text' &&
@@ -12,29 +12,29 @@ export const enter = (node, parent, state) => {
     parent.parent &&
     (parent.parent.backgroundImage || parent.parent.ensureBackgroundColor)
   ) {
-    node.ensureBackgroundColor = true;
+    node.ensureBackgroundColor = true
   }
 
   if (node.action) {
-    const block = 'TouchableNativeFeedback';
-    state.use(block);
+    const block = 'TouchableNativeFeedback'
+    state.use(block)
     state.render.push(
       `<${block}
           activeOpacity={0.7}
           onPress=${wrap(node.action)}
           underlayColor='transparent'>`
-    );
-    node.wrapEnd = `</${block}>`;
+    )
+    node.wrapEnd = `</${block}>`
   } else if (node.teleport) {
-    state.use('Link');
-    let to = getProp(node, 'teleportTo').value.value;
+    state.use('Link')
+    let to = getProp(node, 'teleportTo').value.value
 
     if (to.startsWith('/') || to === '..') {
-      to = safe(to);
+      to = safe(to)
     } else {
-      to = isCode(to) ? `\${${to}}` : to;
-      to = `{\`\${props.match.url === '/' ? '' : props.match.url}/${to}\`}`;
-      state.withRouter = true;
+      to = isCode(to) ? `\${${to}}` : to
+      to = `{\`\${props.match.url === '/' ? '' : props.match.url}/${to}\`}`
+      state.withRouter = true
     }
 
     state.render.push(
@@ -42,16 +42,16 @@ export const enter = (node, parent, state) => {
           activeOpacity={0.7}
           to=${to}
           underlayColor='transparent'>`
-    );
-    node.wrapEnd = '</Link>';
+    )
+    node.wrapEnd = '</Link>'
   } else if (node.goTo) {
     // const goTo = getProp(node, 'goTo')
     // TODO https://facebook.github.io/react-native/docs/linking.html
   }
-};
+}
 
 export const leave = (node, parent, state) => {
   if (node.wrapEnd) {
-    state.render.push(node.wrapEnd);
+    state.render.push(node.wrapEnd)
   }
-};
+}


### PR DESCRIPTION
There are cases some cases where we want to handle the feedback coming from a touchable object.
Views translates all touchables to `TouchableWithoutFeedback` which actually doesn't let you get any feedback. That's why we suggest compiling to `TouchableNativeFeedback`.

Moreover, if we go react native [docs](https://facebook.github.io/react-native/docs/touchablewithoutfeedback.html) is speficically says:

**Do not use unless you have a very good reason. All elements that respond to press should have a visual feedback when touched.**

@dariocravero @tomatuxtemple 